### PR TITLE
Update dns.py

### DIFF
--- a/dns.py
+++ b/dns.py
@@ -22,7 +22,7 @@ if __name__ == '__main__':
     udp_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     udp_sock.bind(("0.0.0.0", args.port))
 
-
+    allow_all = False
     w_list = []
     if environ.get("DNS_ALLOW_ALL") == "YES" or args.whitelist == "ALL":
         allow_all = True


### PR DESCRIPTION
fix for allow_all is not defined 
```
[root@localhost ~]# docker logs byosh
Traceback (most recent call last):
  File "/opt/dns.py", line 41, in <module>
    if (not allow_all) and (w_list != [] and (not any(s[1:] in str(qdom) for s in w_list))):
NameError: name 'allow_all' is not defined
Failed to start dns: 1
```