### PR TITLE
exec: \"./entrypoint.sh\": permission denied

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,6 @@ COPY dns.py /opt/dns.py
 COPY domains /opt/domains
 COPY entrypoint.sh /entrypoint.sh
 
+RUN chmod +x /entrypoint.sh
+
 ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
Using PAAS I had to change the permission on docker file. Doing it before zipping the files did not work some how. 
Please review this from security standpoint

Error details:
```
ContainerCannotRun
er process caused "exec: \"./entrypoint.sh\": permission denied": unknown
Failed	Error: failed to start container "byosh-service": Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused "exec: \"./entrypoint.sh\": permission denied": unknown
```